### PR TITLE
Improved performance of processing directories

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,145 @@
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+
+# All files
+[*]
+indent_style = tabs
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion
+
+###############################
+# Suppression of messages     #
+###############################
+[*.{cs,vb}]
+# IDE0079: Remove unnecessary suppression
+# Reason: Non standard warnings should be left in to support smoother merge to upstream
+dotnet_diagnostic.IDE0079.severity = silent
+
+# IDE0057: Use range operator
+# Reason: Range operators are not suppored by netstandard
+dotnet_diagnostic.IDE0057.severity = silent

--- a/GitignoreParser.cs
+++ b/GitignoreParser.cs
@@ -105,7 +105,7 @@ namespace GitignoreParserNet
 
             var fileResults = parser.ProcessFiles(directory);
             var accepted = fileResults.Where(x => x.Accepted).Select(x => x.FilePath).ToArray();
-            var denied = fileResults.Where(x => x.Accepted).Select(x => x.FilePath).ToArray();
+            var denied = fileResults.Where(x => x.Denied).Select(x => x.FilePath).ToArray();
 
             return (accepted, denied);
         }
@@ -128,7 +128,7 @@ namespace GitignoreParserNet
 
             var fileResults = parser.ProcessFiles(directory);
             var accepted = fileResults.Where(x => x.Accepted).Select(x => x.FilePath).ToArray();
-            var denied = fileResults.Where(x => x.Accepted).Select(x => x.FilePath).ToArray();
+            var denied = fileResults.Where(x => x.Denied).Select(x => x.FilePath).ToArray();
 
             return (accepted, denied);
         }

--- a/GitignoreParser.cs
+++ b/GitignoreParser.cs
@@ -130,24 +130,15 @@ namespace GitignoreParserNet
         /// </summary>
         /// <param name="directory">The directory to traverse.</param>
         /// <returns>The list of relative paths of subdirectories and files.</returns>
-        private static List<string> ListFiles(DirectoryInfo directory)
+        private static string[] ListFiles(DirectoryInfo directory)
         {
-            static List<string> AaddFiles(List<string> files, DirectoryInfo directory, string rootPath)
-            {
-                files.Add(directory.FullName.Substring(rootPath.Length) + '/');
+            var directoryPath = directory.FullName;
+            var files = Directory.GetFiles(directoryPath, "*.*", SearchOption.AllDirectories)
+                .Select(f => f.Substring(directoryPath.Length + 1))
+                .ToList();
+            files.Insert(0, "/");
 
-                foreach (FileInfo file in directory.GetFiles())
-                    files.Add(file.FullName.Substring(rootPath.Length + 1));
-
-                foreach (DirectoryInfo subDir in directory.GetDirectories())
-                    files.AddRange(AaddFiles(files, subDir, rootPath));
-
-                return files;
-            }
-
-            List<string> files = [];
-            AaddFiles(files, directory, directory.FullName);
-            return files;
+            return [.. files];
         }
 
         /// <summary>

--- a/GitignoreParser.cs
+++ b/GitignoreParser.cs
@@ -20,6 +20,8 @@ namespace GitignoreParserNet
     /// <seealso href="https://github.com/GerHobbelt"/>
     public sealed class GitignoreParser
     {
+        private static readonly string[] LINEBREAKS = ["\r\n", "\r", "\n"];
+
         private readonly (Regex Merged, Regex[] Individual) Positives;
         private readonly (Regex Merged, Regex[] Individual) Negatives;
 
@@ -55,7 +57,7 @@ namespace GitignoreParserNet
             var regexOptions = compileRegex ? RegexOptions.Compiled : RegexOptions.None;
 
             (List<string> positive, List<string> negative) = content
-                .Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)
+                .Split(LINEBREAKS, StringSplitOptions.None)
                 .Select(line => line.Trim())
                 .Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith('#'))
                 .Aggregate<string, (List<string>, List<string>), (List<string>, List<string>)>(
@@ -100,6 +102,7 @@ namespace GitignoreParserNet
         {
             GitignoreParser parser = new(content, false);
             DirectoryInfo directory = new(directoryPath);
+
             return (parser.Accepted(directory), parser.Denied(directory));
         }
 


### PR DESCRIPTION
The processing of deep directory structures failed with an error and was incedibly slow. The main reason for this was the methof obtaing the files. By utilizing system functionality of System.IO the process could be sped up significantly.

In addition the directory based static Parse method obtained and processed the files twice. This was reduce  to once by having a visitor method evaluating accepted and denied for each file.

In addition I added an .editorconfig to harmonize the coding conventions and message suppressions.