### PR TITLE
NuGet: update the license metadata

### DIFF
--- a/GitignoreParserNet.csproj
+++ b/GitignoreParserNet.csproj
@@ -15,7 +15,7 @@
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Copyright>Copyright 2014 codemix ltd.; Copyright (c) 2021 Gyuirgy</Copyright>
+    <Copyright>Copyright 2014 codemix ltd.; Copyright (c) 2021 Guiorgy</Copyright>
     <Description>A simple yet complete .gitignore parser for .NET.
 Supports all features listed in the git-scm gitignore manpage.</Description>
     <PackageIcon>Gitignore.png</PackageIcon>

--- a/GitignoreParserNet.csproj
+++ b/GitignoreParserNet.csproj
@@ -8,15 +8,14 @@
     <LangVersion>12</LangVersion>
     <RootNamespace>GitignoreParserNet</RootNamespace>
     <Authors>Guiorgy</Authors>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Guiorgy/GitignoreParserNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Guiorgy/GitignoreParserNet</RepositoryUrl>
     <Version>0.2.0.12</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Copyright>Guiorgy</Copyright>
+    <Copyright>Copyright 2014 codemix ltd.; Copyright (c) 2021 Gyuirgy</Copyright>
     <Description>A simple yet complete .gitignore parser for .NET.
 Supports all features listed in the git-scm gitignore manpage.</Description>
     <PackageIcon>Gitignore.png</PackageIcon>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Gyuirgy
+# Copyright (c) 2021 Guiorgy
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this project except in compliance with the License.


### PR DESCRIPTION
Hello! I am working on a tool that examines the NuGet license metadata (using this very library, so thank you!), and found that the licensing information in the package may be improved. There are no _problems_ with the current package, mind you! Just some minor inaccuracies I decided to fix. The changes include:

- SPDX expression instead of file.

  **Why?** It allows immediately seeing the exact license terms in various automated tools, instead of the need to manually inspect the license file.
- Copyright statements in the metadata.

  **Why?** Normally, the full copyright statement should follow the SPDX expression (as the copyright statement is in most cases the only part of the license that changes between different projects).

  **Note:** I have noticed that there are different spellings of your name in your GitHub account and the license file. I am sorry, and I don't know which you may prefer, so for now I've used the one that was in the license file. This is not a problem if you decide to synchronize these and update the license and the `<Copyright>` field in the metadata.

  Another note is that there is no 100% preferred copyright year that would be recommended to leave in the copyright statement: in some cases, people prefer to leave the "year of the first publication", in some cases year of the last publication, in some cases both. So, it's not that important which particular year you choose. For now, I've refused the same information from the license.
- Do not require license acceptance.

  **Why?** In most cases, this is used for corporate EULA statements that legally require the user to read and "sign"/"accept" the license. For permissive licenses, it's normally not necessary.

  It is totally okay if you think we should restore this field, though.

**Additional note**: since this only updates the package metadata, I don't want to add any pressure and ask you to publish a package with this update. Most of the package analysis tools already provide a way to override the package license metadata for select packages, so if you choose to merge this, take your time to publish the new package version; there is absolutely no rush.